### PR TITLE
Fixes: remove grading, move list to top of page.

### DIFF
--- a/.vscode/vendor.code-snippets
+++ b/.vscode/vendor.code-snippets
@@ -5,13 +5,11 @@
 		"body": [
 			"name = \"$1\"",
 			"url = \"$2\"",
-			"grade = \"$3\"",
 			"issues = [",
 			"\t\"$0\"",
 			"]",
-			"gating_mechanism = \"$4\"",
-			"source = \"$5\"",
-
+			"gating_mechanism = \"$3\"",
+			"source = \"$4\"",
 		],
 		"description": "Create new vendor entry"
 	}

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A list of vendors that don't prioritize high-quality, widely-available audit log
 
 Vendor data for the table lives in [`data/vendors`](data/vendors/)
 
-Current grading is set to "N" until a framework for grading is implemented.
-
-The team is working on a Unified Log Standard with other security engineers to best grade vendors on log quality. The goal is to demonstrate common pitfalls and how to avoid these so log quality is improved. 
-
 Great detection requires great logs!
 
 To contribute, check out the contributing guidelines and make a pull request. All ideas are welcome.
@@ -15,5 +11,5 @@ To contribute, check out the contributing guidelines and make a pull request. Al
 
 ## Maintainers
 
-@shellchromancer
-@julieagnessparks
+* [shellchromancer](https://github.com/shellcromancer)
+* [julieagnessparks](https://github.com/julieagnessparks)

--- a/content/_index.md
+++ b/content/_index.md
@@ -30,39 +30,26 @@ The purpose is to push those building solutions to think of the security enginee
 
 For example, added sources may only provide audit logs to high paying enterprise tiers (Zendesk), provide higher quality logs with increased pricing tiers (GitHub), or have audit logs that are a separate package from even enterprise tiers (Salesforce).
 
-### Audit Log Quality Matrix Framework
+### Audit Log Quality
 
-*Log Content* (4pts)
+Improving security engineers experience with audit logs spans across: the log content, how engineers can collect them.
+
+*Log Content*
 - Event types cover all actions taken in the system and include critical fields, such as source ip address.
 - Audit logs have external facing documentation on event types.
 - Logs contain enough information to attribute activity to a user within the platform.
 - The ability to get detailed audit logs is part of the core product or reasonably priced.
 
-*Log Collection* (3pts)
+*Log Collection*
 - The ability exists to stream logs to a cloud storage or SIEM provider (such as logpush to S3). Otherwise the API to self-retrieve logs is straightforward, documented and allows engineers to easily retrieve their logs. 
 - Log collection makes it possible for event IDs to be sorted and straightforward in order to not miss log events or get duplicate events in the pipeline.
 - There is good log formatting and data structure choice, making it easy to parse logs once they are retrieved.
 
-*Quality & Consistency* (3pts)
-- There is log constistency across product versioning and operating systems, including when pulling the logs. Backwards compatability introduced when needed.
+*Quality & Consistency*
+- There is log consistency across product versioning and operating systems, including when pulling the logs. Backwards compatibility introduced when needed.
 - Low rate of log quality related incidents. Logs are reliable and can be taken as a source of truth.
 - There is limited latency between when an action occurs and when the log event is available.
 
-
-#### Grading Scale
-Log sources that are added will be graded from a scale of 0 - 10 with an associated lettering based on the Audit Log Quality Framework above.
-
-- 10/10 A+
-- 9/10 A
-- 8/10 B+
-- 7/10 B
-- 6/10 C+
-- 5/10 C
-- 4/10 D+
-- 3/10 D
-- 2/10 F+
-- 1/10 F
-- 0/10 F-
 
 ### What are some examples of qualities that make a log “bad”?
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -34,18 +34,18 @@ For example, added sources may only provide audit logs to high paying enterprise
 
 Improving security engineers experience with audit logs spans across: the log content, how engineers can collect them.
 
-*Log Content*
+#### Log Content
 - Event types cover all actions taken in the system and include critical fields, such as source ip address.
 - Audit logs have external facing documentation on event types.
 - Logs contain enough information to attribute activity to a user within the platform.
 - The ability to get detailed audit logs is part of the core product or reasonably priced.
 
-*Log Collection*
+#### Log Collection
 - The ability exists to stream logs to a cloud storage or SIEM provider (such as logpush to S3). Otherwise the API to self-retrieve logs is straightforward, documented and allows engineers to easily retrieve their logs. 
 - Log collection makes it possible for event IDs to be sorted and straightforward in order to not miss log events or get duplicate events in the pipeline.
 - There is good log formatting and data structure choice, making it easy to parse logs once they are retrieved.
 
-*Quality & Consistency*
+ #### Quality & Consistency
 - There is log consistency across product versioning and operating systems, including when pulling the logs. Backwards compatibility introduced when needed.
 - Low rate of log quality related incidents. Logs are reliable and can be taken as a source of truth.
 - There is limited latency between when an action occurs and when the log event is available.

--- a/data/vendors/1password.toml
+++ b/data/vendors/1password.toml
@@ -1,6 +1,5 @@
 name = "1Password"
 url = "https://1password.com"
-grade = "C"
 issues = [
     "Does not use UTC or standarizded time for timestamps",
     "Lack of documentation on what event types represent",

--- a/data/vendors/atlassian-jira.toml
+++ b/data/vendors/atlassian-jira.toml
@@ -1,6 +1,5 @@
 name = "Atlassian Cloud"
 url = "https://jira.atlassian.com/"
-grade = "A"
 issues = [
     "None noted at this time.",
 ]

--- a/data/vendors/aws.toml
+++ b/data/vendors/aws.toml
@@ -7,5 +7,5 @@ issues = [
     "Lack of metadata surrounding specific event types, such as failed authentication attempts to the console",
     "Not all events are logged, which are demonstrated by exploits found by attackers",
 ]
-gating_mechanism = "Usage Based"
+gating_mechanism = "Usage Based Billing"
 source = "https://aws.amazon.com/cloudtrail/pricing/"

--- a/data/vendors/aws.toml
+++ b/data/vendors/aws.toml
@@ -1,6 +1,5 @@
 name = "AWS Cloudtrail"
 url = "https://aws.amazon.com/cloudtrail"
-grade = "C+"
 issues = [
     "Nested unordered arrays that are inconsistently present in the same event IDs",
     "Unknown log delivery delays",

--- a/data/vendors/docusign.toml
+++ b/data/vendors/docusign.toml
@@ -1,6 +1,5 @@
 name = "DocuSign"
 url = "https://www.docusign.com/"
-grade = "C"
 issues = [
     "Collection: Small page limits"
 ]

--- a/data/vendors/github.toml
+++ b/data/vendors/github.toml
@@ -1,6 +1,5 @@
 name = "GitHub"
 url = "https://github.com"
-grade = "C"
 issues = [
     "Logs don't link to company email",
     "Standard logs don't include IPs",

--- a/data/vendors/gitlab.toml
+++ b/data/vendors/gitlab.toml
@@ -1,6 +1,5 @@
 name = "Gitlab"
 url = "https://about.gitlab.com"
-grade = "B"
 issues = [
     "Forces you to pay for the highest tier to stream events",
     "Does not include audit events for project settings, group settings, or deployment approval activity.",

--- a/data/vendors/jamf.toml
+++ b/data/vendors/jamf.toml
@@ -1,6 +1,5 @@
 name = "JAMF PRO"
 url = "https://www.jamf.com"
-grade = "D"
 issues = [
     "Can only export logs via the UI, in batches of 500 messages per export.",
     "If you don't want to use the UI, you have to manually poll each machine in your environment to get the machines audit logs.",

--- a/data/vendors/lastpass.toml
+++ b/data/vendors/lastpass.toml
@@ -1,6 +1,5 @@
 name = "LastPass"
 url = "https://www.lastpass.com/"
-grade = "C"
 issues = [
     "Poor support for Enterprise API to pull audit logs",
     "Lack of external documentation on what event types are available and what they represent",

--- a/data/vendors/notion.toml
+++ b/data/vendors/notion.toml
@@ -1,6 +1,5 @@
 name = "Notion"
 url = "https://www.notion.so/"
-grade = "F"
 issues = [
     "No API collection",
 ]

--- a/data/vendors/salesforce.toml
+++ b/data/vendors/salesforce.toml
@@ -1,6 +1,5 @@
 name = "Salesforce"
 url = "https://salesforce.com"
-grade = "C"
 issues = [
     "24 hour delay in log generation",
     "Output to CSV via SOQL API is not user friendly",

--- a/data/vendors/slack.toml
+++ b/data/vendors/slack.toml
@@ -1,6 +1,5 @@
 name = "Slack"
 url = "https://slack.com"
-grade = "A"
 issues = [
     "None noted at this time",
 ]

--- a/data/vendors/stripe.toml
+++ b/data/vendors/stripe.toml
@@ -1,6 +1,5 @@
 name = "Stripe"
 url = "https://stripe.com/"
-grade = "F"
 issues = [
     "Logs only a subset of activity, no administrative audit logging",
     "Lack of documentation on what security logging is available",

--- a/data/vendors/zendesk.toml
+++ b/data/vendors/zendesk.toml
@@ -1,6 +1,5 @@
 name = "Zendesk"
 url = "https://www.zendesk.com/"
-grade = "B"
 issues = [
     "No issues noted at this time."
 ]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,6 @@
                 <th>Vendor</th>
                 <th>Cost Increase</th>
                 <th>Log Issues</th>
-                <th>Overall Grade</th>
             </tr>
             {{ range $.Site.Data.vendors }}
             {{ partial "vendor.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,21 +7,22 @@
         {{ end }}
     </header>
     <div class="homepage-content">
-        <!-- Note that the content for index.html, as a sort of list page, will pull from content/_index.md -->
-        {{.Content}}
 
         <h2>The List</h2>
         <!-- Content will be pulled from data/vendors/* and filled in via layouts/partials/vendor -->
         <table>
             <tr>
                 <th>Vendor</th>
-                <th>Cost Increase</th>
+                <th>Gating Mechanism</th>
                 <th>Log Issues</th>
             </tr>
             {{ range $.Site.Data.vendors }}
             {{ partial "vendor.html" . }}
             {{ end }}
         </table>
+
+        <!-- Note that the content for index.html, as a sort of list page, will pull from content/_index.md -->
+        {{.Content}}
 
     </div>
     <div>

--- a/layouts/partials/vendor.html
+++ b/layouts/partials/vendor.html
@@ -8,5 +8,4 @@
             {{ end }}
         </ul>
     </td>
-    <td> {{ .grade }} </td>
 </tr>


### PR DESCRIPTION
After discussion around the value of the site, and the "taxation" concept we should focus the site on the availability of audit logs, less so on giving precise scores for audit logs qualms. The rationale here is that for vendors and practitioners the grade is less useful than the list of issues themselves so let's remove this more contentious and subjective portion.