### PR TITLE
feat: add Terraform Cloud to the wall

### DIFF
--- a/data/vendors/hashicorp-terraform.toml
+++ b/data/vendors/hashicorp-terraform.toml
@@ -1,0 +1,8 @@
+name = "Terraform Cloud"
+url = "https://www.hashicorp.com/products/terraform"
+issues = [
+    "Lacking audit data (Requests: source IP, user-agent. Changes: previous and current values)",
+    "Lacking response documentation (Possible resource values, meta KVs)"
+]
+gating_mechanism = "Higher Tier (Plus/Enterprise only)"
+source = "https://www.hashicorp.com/products/terraform/pricing"

--- a/data/vendors/hashicorp-terraform.toml
+++ b/data/vendors/hashicorp-terraform.toml
@@ -2,7 +2,9 @@ name = "Terraform Cloud"
 url = "https://www.hashicorp.com/products/terraform"
 issues = [
     "Lacking audit data (Requests: source IP, user-agent. Changes: previous and current values)",
-    "Lacking response documentation (Possible resource values, meta KVs)"
+    "Lacking response documentation (Possible resource values, meta KVs)",
+    "No documentation of expected event types within Audit Trail logging",
+    "Audit Trail logs and application logs are omitted together."
 ]
 gating_mechanism = "Higher Tier (Plus/Enterprise only)"
 source = "https://www.hashicorp.com/products/terraform/pricing"


### PR DESCRIPTION
Adds Terraform Cloud based on their tier based gating of audit log data [1], [2] and include helpful incident response data that is omitted from logging.

> Note: Audit trails are available in Terraform Cloud Plus Edition. Refer to [Terraform Cloud pricing](https://www.hashicorp.com/products/terraform/pricing) for details. The Audit Trails API is not available for Terraform Enterprise.

1. https://developer.hashicorp.com/terraform/cloud-docs/api-docs/audit-trails
2. https://www.hashicorp.com/products/terraform/pricing